### PR TITLE
ORAKEI-21: Added global layout component and applied to existing pages

### DIFF
--- a/src/components/footer.astro
+++ b/src/components/footer.astro
@@ -12,7 +12,7 @@ import '../styles/footer.css';
 
 <div class="feet">
     <div class="logoContainer">
-        <img class="footLogo" src="src/icons/YOO_Logo_Transparent_Background.png">
+        <img class="footLogo" src="/YOO_Logo_Transparent_Background.png">
     </div>
 
     <div class="socials">

--- a/src/layouts/layout.astro
+++ b/src/layouts/layout.astro
@@ -1,0 +1,29 @@
+<!--
+This is the global layout, reflecting the common components to all pages (header, footer, and anything else we might add.
+ -->
+
+---
+import "../styles/global.css";
+
+import Header from "../components/header.astro";
+import Footer from "../components/footer.astro";
+---
+
+<!-- TODO Make title and description props from each page -->
+
+<html lang="en">
+	<head>
+		<meta charset="utf-8" />
+		<link rel="icon" type="image/svg+xml" href="/favicon.svg" />
+		<meta name="viewport" content="width=device-width" />
+		<meta name="generator" content={Astro.generator} />
+		<title>Youth of Ōrākei</title>
+	</head>
+	<body>
+		<Header />
+		<main>
+			<slot />
+		</main>
+		<Footer />
+	</body>
+</html>

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -8,9 +8,8 @@ import Layout from '../layouts/layout.astro'
     <meta name="generator" content={Astro.generator} />
     <title>Contact Page</title>
     <style>
-        body {
-            background-color: #C8E4AE;
-            margin: auto;
+        .contact-wrapper {
+            background-color: var(--YOO-Green-Lightest);
         }
         .content-container{
             display: flex;
@@ -65,34 +64,34 @@ import Layout from '../layouts/layout.astro'
 </head>
 
 <Layout>
-<body>
-    <h1>Contact Us</h1>
-    <div class = "content-container">
-        <form>
-            <div class="form-group">
-                <label for="full-name">Full Name</label> <br>
-                <input type="text" id="full-name" name="full_name"><br>
-            </div>
-            <div class="form-group">
-                <label for="school">School</label><br>
-                <input type="text" id="school" name="school"><br>
-            </div>
-            <div class="form-group">
-                <label for="email">Email</label><br>
-                <input type="email" id="email" name="email"><br>
-            </div>
-            <div class="form-group">
-                <label for="message">Message</label><br>
-                <textarea id="message" name="message"></textarea>
-            </div>
-            <div class="form-group">
-                <button type="submit"> Submit</button>
-            </div>
-        </form>
+    <div class="contact-wrapper">
+        <h1>Contact Us</h1>
+        <div class = "content-container">
+            <form>
+                <div class="form-group">
+                    <label for="full-name">Full Name</label> <br>
+                    <input type="text" id="full-name" name="full_name"><br>
+                </div>
+                <div class="form-group">
+                    <label for="school">School</label><br>
+                    <input type="text" id="school" name="school"><br>
+                </div>
+                <div class="form-group">
+                    <label for="email">Email</label><br>
+                    <input type="email" id="email" name="email"><br>
+                </div>
+                <div class="form-group">
+                    <label for="message">Message</label><br>
+                    <textarea id="message" name="message"></textarea>
+                </div>
+                <div class="form-group">
+                    <button type="submit"> Submit</button>
+                </div>
+            </form>
 
-        <div class="contact-image">
-            <img src="src/pages/images/contact-us-stock-image.png" alt="contact us stock image">
+            <div class="contact-image">
+                <img src="src/pages/images/contact-us-stock-image.png" alt="contact us stock image">
+            </div>
         </div>
     </div>
-</body>
 </Layout>

--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -1,4 +1,6 @@
-<html lang="en">
+---
+import Layout from '../layouts/layout.astro'
+---
 <head>
     <meta charset="utf-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
@@ -45,10 +47,10 @@
         input, textarea{
         background-color: #D9EBEF;
         width: 100%;
-        padding: 1%; 
-        font-size: 15px; 
-        border: 2px solid #A4C6B0; 
-        border-radius: 5px; 
+        padding: 1%;
+        font-size: 15px;
+        border: 2px solid #A4C6B0;
+        border-radius: 5px;
         box-sizing: border-box;
     }
 
@@ -57,10 +59,12 @@
     }
 
     .contact-image{
-        flex: 1; 
+        flex: 1;
     }
     </style>
 </head>
+
+<Layout>
 <body>
     <h1>Contact Us</h1>
     <div class = "content-container">
@@ -86,9 +90,9 @@
             </div>
         </form>
 
-        <div class="contact-image"> 
+        <div class="contact-image">
             <img src="src/pages/images/contact-us-stock-image.png" alt="contact us stock image">
         </div>
     </div>
 </body>
-</html>
+</Layout>

--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -3,8 +3,7 @@
 import "../styles/global.css";
 import "../styles/index.css";
 
-import Header from "../components/header.astro";
-import Footer from "../components/footer.astro";
+import Layout from '../layouts/layout.astro';
 ---
 
 <html lang="en">
@@ -15,8 +14,7 @@ import Footer from "../components/footer.astro";
 		<meta name="generator" content={Astro.generator} />
 		<title>Homepage</title>
 	</head>
-	<body>
-		<Header />
+	<Layout>
 		<div class="hero">
 			<img class="hero-bg" alt = "abstract background shapes" src="src/assets/YOO_index-hero-bg.svg">
 			<div class="general-wrapper">
@@ -118,7 +116,5 @@ import Footer from "../components/footer.astro";
 				</div>
 			</div>
 		</section>
-
-		<Footer />
-	</body>
+	</Layout>
 </html>

--- a/src/pages/members.astro
+++ b/src/pages/members.astro
@@ -5,6 +5,7 @@ import "../styles/members.css";
 
 import Header from "../components/header.astro";
 import Footer from "../components/footer.astro";
+import Layout from '../layouts/layout.astro';
 
 import TeamDisplay from "../components/TeamDisplay.astro";
 ---
@@ -152,7 +153,7 @@ import TeamDisplay from "../components/TeamDisplay.astro";
     <title>Astro</title>
   </head>
 
-  <body>
+  <Layout>
     <div>
       <h1 class="title">INTRODUCING OUR TEAMS</h1>
     </div>
@@ -266,5 +267,5 @@ import TeamDisplay from "../components/TeamDisplay.astro";
         </ul>
       </div>
     </div>
-  </body>
+  </Layout>
 </html>

--- a/src/pages/members.astro
+++ b/src/pages/members.astro
@@ -127,13 +127,6 @@ import TeamDisplay from "../components/TeamDisplay.astro";
         margin-top: 100%;
       }
 
-      body {
-        margin: 0 auto;
-        width: 100%;
-        padding: 1rem;
-        line-height: 1.5;
-      }
-
       .project-team-nav {
         display: flex;
         flex-direction: column;

--- a/src/pages/projects.astro
+++ b/src/pages/projects.astro
@@ -2,6 +2,8 @@
 // Projects Page
 import '../styles/global.css';
 import TeamDisplay from '../components/TeamDisplay.astro';
+import Layout from '../layouts/layout.astro';
+
 ---
 
 <html lang="en">
@@ -12,8 +14,8 @@ import TeamDisplay from '../components/TeamDisplay.astro';
 		<meta name="generator" content={Astro.generator} />
 		<title>Projects</title>
 	</head>
-	<body>
+	<Layout>
 		<h1>Projects</h1>
 		<TeamDisplay />
-	</body>
+	</Layout>
 </html>


### PR DESCRIPTION
Global layout `layout.astro` contained in new `layouts `directory. At the moment, the global layout contains only the footer and header (plus its children).

The layout is applied as a _replacement_ to the `body` tag on all the existing pages - some minor css edits were done on pages that used this tag for styling but it should be non-destructive!
