### PR TITLE
added fallbackstring in case the web form token doesn't exist

### DIFF
--- a/src/pages/contact.astro
+++ b/src/pages/contact.astro
@@ -1,6 +1,6 @@
 ---
 import Layout from '../layouts/layout.astro'
-const form_token = import.meta.env.WEBFORMS_TOKEN;
+const form_token = import.meta.env.WEBFORMS_TOKEN || 'fallback-string';
 ---
 <head>
     <meta charset="utf-8" />


### PR DESCRIPTION
In staging, there is no .env file so the token cannot be loaded, the page wasn't loading before as it was looking for the webforms token in the env file. Since the env variables don't exist yet in staging I added a temporary fallback-string in the case where the form token doesn't exist.